### PR TITLE
Fix tmux-keybindings.conf for tmux v3

### DIFF
--- a/tmux/tmux-keybindings.conf
+++ b/tmux/tmux-keybindings.conf
@@ -29,12 +29,12 @@ bind -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
 bind -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
 bind -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
 bind -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
-bind -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
+bind -n 'C-\' if-shell "$is_vim" "send-keys 'C-\\'" "select-pane -l"
 bind -T copy-mode-vi C-h select-pane -L
 bind -T copy-mode-vi C-j select-pane -D
 bind -T copy-mode-vi C-k select-pane -U
 bind -T copy-mode-vi C-l select-pane -R
-bind -T copy-mode-vi C-\ select-pane -l
+bind -T copy-mode-vi 'C-\' select-pane -l
 
 # window nav
 bind n next-window


### PR DESCRIPTION
Because of changes to config parsing in tmux v3, use single quotes
around backslash (\) characters.

Fix will resolve errors in v3 and is backwards compatible previous
versions of tmux.

Issue from: https://raw.githubusercontent.com/tmux/tmux/3.0/CHANGES

* INCOMPATIBLE: tmux's configuration parsing has changed to use yacc(1). There
  is one incompatible change: a \ on its own must be escaped or quoted as
  either \\ or '\' (the latter works on older tmux versions).