### PR TITLE
Add nvim plugin set-clipboard-linux.vim

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -144,9 +144,13 @@ function link_dotfiles {
   ln -s "$HOME/.dotfiles/vim/init.vim" "$HOME/.vimrc"
   # neovim -> vim
   mkdir -p "$HOME/.config"
-  mkdir -p "$HOME/.vim"
+  mkdir -p "$HOME/.vim/plugin"
   ln -s "$HOME/.vimrc" "$HOME/.vim/init.vim"
   ln -s "$HOME/.vim" "$HOME/.config/nvim"
+  # set linux clipboard option
+  if [[ $(uname -s) == "Linux" ]]; then
+    echo 'set clipboard=unnamedplus' > "$HOME/.vim/plugin/set-clipboard-linux.vim"
+  fi
 }
 
 function fix_permissions {


### PR DESCRIPTION
Linux uses clipboard 'unnamedplus' instead of 'unnamed' like macOS &
Windows.  Update the deploy script to create this one-line plugin in ~/.vim/plugin if Linux is detected, which will run after the base init.vim to change the clipboard setting.