### PR TITLE
chore: safe fasd

### DIFF
--- a/zsh/zshrc.sh
+++ b/zsh/zshrc.sh
@@ -96,17 +96,19 @@ setopt AUTO_PUSHD
 setopt AUTO_CD
 
 # fasd
-eval "$(fasd --init auto)"
-alias a='fasd -a'        # any
-alias s='fasd -si'       # show / search / select
-alias d='fasd -d'        # directory
-alias f='fasd -f'        # file
-alias sd='fasd -sid'     # interactive directory selection
-alias sf='fasd -sif'     # interactive file selection
-alias z='fasd_cd -d'     # cd, same functionality as j in autojump
-alias zz='fasd_cd -d -i' # cd with interactive selection
-alias v='f -e vim'       # open in (neo-)vim
-export _FASD_MAX=1000
+if [[ "$(command -v fasd)" ]]; then
+  eval "$(fasd --init auto)"
+  alias a='fasd -a'        # any
+  alias s='fasd -si'       # show / search / select
+  alias d='fasd -d'        # directory
+  alias f='fasd -f'        # file
+  alias sd='fasd -sid'     # interactive directory selection
+  alias sf='fasd -sif'     # interactive file selection
+  alias z='fasd_cd -d'     # cd, same functionality as j in autojump
+  alias zz='fasd_cd -d -i' # cd with interactive selection
+  alias v='f -e vim'       # open in (neo-)vim
+  export _FASD_MAX=1000
+fi
 
 # safety first
 set -o noclobber         # Do not overwrite files via '>'


### PR DESCRIPTION
Ensure that we only attempt to initialize and assign aliases to `fasd` for jump functionality if it has been installed.