### PR TITLE
feat: enhance vim config for python + js development

### DIFF
--- a/vim/init.vim
+++ b/vim/init.vim
@@ -119,16 +119,35 @@ call plug#begin('~/.vim/plugged')
   " buffer deletion w/ layout preservation
   Plug 'qpkorr/vim-bufkill'
 
-  " linting
-  Plug 'w0rp/ale'
-
   " testing
   Plug 'janko-m/vim-test'
 
 call plug#end()
 
 " coc extensions
-let g:coc_global_extensions = ['coc-tslint-plugin', 'coc-eslint', 'coc-tsserver', 'coc-emmet', 'coc-css', 'coc-html', 'coc-json', 'coc-yank', 'coc-prettier']
+
+augroup coc_plugins
+  autocmd!
+  autocmd Filetype python let g:coc_global_extensions = ['coc-json', 'coc-yank', 'coc-python']
+  autocmd Filetype javascriptreact,javascript let g:coc_global_extensions = [
+    \'coc-tslint-plugin',
+    \'coc-eslint',
+    \'coc-tsserver',
+    \'coc-emmet',
+    \'coc-css',
+    \'coc-html',
+    \'coc-json',
+    \'coc-yank',
+    \'coc-prettier'
+    \]
+augroup END
+
+augroup coc_workspace_roots
+  autocmd!
+  autocmd Filetype python let b:coc_root_patterns = ['.git', 'requirements.txt']
+  autocmd Filetype javascriptreact let b:coc_root_patterns = ['.git', 'package.json']
+  autocmd Filetype javascript let b:coc_root_patterns = ['.git', 'package.json']
+augroup END
 
 " use <tab> for trigger completion and navigate to the next complete item
 function! s:check_back_space() abort
@@ -140,24 +159,25 @@ inoremap <silent><expr> <Tab>
       \ pumvisible() ? "\<C-n>" :
       \ <SID>check_back_space() ? "\<Tab>" :
       \ coc#refresh()
-
 inoremap <expr> <cr> pumvisible() ? "\<C-y>" : "\<C-g>u\<CR>"
-
 inoremap <expr> <Tab> pumvisible() ? "\<C-n>" : "\<Tab>"
 inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
 
 augroup typescript_register
+  autocmd!
   autocmd BufNewFile,BufRead *.ts setlocal filetype=typescript
   autocmd BufNewFile,BufRead *.tsx setlocal filetype=typescript.tsx
 augroup END
 
 augroup json_comments
+  autocmd!
   autocmd FileType json syntax match Comment +\/\/.\+$+
 augroup END
 
 " allow autocompletion on all filetypes except txt
 let g:deoplete#enable_at_startup=1
 augroup deoplete_configs
+  autocmd!
   autocmd FileType tex call deoplete#custom#buffer_option('auto_complete', v:false)
 augroup END
 
@@ -183,6 +203,7 @@ let g:ctrlp_custom_ignore = {
 " nerdtree configs
 let NERDTreeRespectWildIgnore=1
 augroup nerdtree_configs
+  autocmd!
   autocmd BufEnter * if (winnr("$") == 1 && exists("b:NERDTree") && b:NERDTree.isTabTree()) | q | endif
   autocmd StdinReadPre * let s:std_in=1
   autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists("s:std_in") | exe 'NERDTree' argv()[0] | wincmd p | ene | endif
@@ -190,6 +211,7 @@ augroup END
 
 " rainbow parentheses
 augroup parentheses_configs
+  autocmd!
   autocmd VimEnter * RainbowParenthesesToggle
   autocmd Syntax * RainbowParenthesesLoadRound
   autocmd Syntax * RainbowParenthesesLoadSquare
@@ -224,35 +246,9 @@ endif
 
 " tern
 augroup tern_js_config
-  au!
-  au CompleteDone * pclose
+  autocmd!
+  autocmd CompleteDone * pclose
 augroup END
-
-" linting & formatting
-let g:ale_fixers = { 
-  \'javascript': ['eslint'],
-  \'javascriptreact': ['eslint'],
-  \'python': ['black'],
-  \'ruby': ['rubocop']
-\}
-let g:ale_fix_on_save = 1
-" let g:ale_linter_aliases = {
-"   \'jsx': ['javascript', 'javascriptreact']
-" \}
-let g:ale_linters = {
-  \'javascript': ['eslint'],
-  \'javascriptreact': ['eslint','stylelint'],
-  \'less': ['stylelint'],
-  \'python': ['flake8'],
-  \'ruby': ['rubocop']
-\}
-let g:ale_linters_explicit = 1
-let g:ale_set_highlights = 0
-let g:airline#extensions#ale#enabled = 1
-" let g:ale_sign_error = '😡'
-" let g:ale_sign_warning = '🤔'
-highlight clear ALEErrorSign
-highlight clear ALEWarningSign
 
 " testing strategy
 let test#strategy = 'vimux'
@@ -307,6 +303,7 @@ set shiftwidth=2
 set expandtab
 " automatic config on filetype
 augroup filetype_configs
+  autocmd!
   " ... not for makefiles tho
   autocmd FileType make setlocal noexpandtab
   autocmd FileType makefile setlocal noexpandtab
@@ -355,6 +352,7 @@ highlight link vimrc_todo Todo
 
 " automatic commands run on sys task
 augroup sys_tasks
+  autocmd!
   " remove trailing space on save unless b:noStripWhitespace
   autocmd FileType vim let b:noStripWhitespace=1
   autocmd BufWritePre * call StripTrailingWhitespace()
@@ -365,11 +363,13 @@ augroup END
 " quickfix window context
 command! RemoveQFItem :call RemoveQFItem()
 augroup qf_window
+  autocmd!
   autocmd FileType qf nnoremap <buffer> dd :call RemoveQFItem()<CR>
 augroup END
 
 " Refresh syntax highlighting on buffer enter
 augroup refreshsyntax_highlighting
+  autocmd!
   autocmd BufEnter *.{js,jsx,ts,tsx} :syntax sync fromstart
   autocmd BufLeave *.{js,jsx,ts,tsx} :syntax sync clear
 augroup END
@@ -435,6 +435,7 @@ if has('nvim')
   " terminal
   tnoremap <Esc> <C-\><C-n>
   augroup terminal_tasks
+    autocmd!
     " remove line numbers in terminal
     autocmd TermOpen * setlocal nonumber norelativenumber
     autocmd TermOpen * startinsert

--- a/vim/init.vim
+++ b/vim/init.vim
@@ -34,6 +34,21 @@ function! RemoveQFItem()
   copen
 endfunction
 
+" Help `gf` resolve filepaths
+set path=.,src,node_modules
+set suffixesadd=.js,.jsx,.ts,.tsx
+function! LoadMainNodeModule(fname)
+    let nodeModules = "./node_modules/"
+    let packageJsonPath = nodeModules . a:fname . "/package.json"
+
+    if filereadable(packageJsonPath)
+        return nodeModules . a:fname . "/" . json_decode(join(readfile(packageJsonPath))).main
+    else
+        return nodeModules . a:fname
+    endif
+endfunction
+
+set includeexpr=LoadMainNodeModule(v:fname)
 
 """""""""""""""""""""""" PLUGINS
 set runtimepath^=~/.vim/plugin

--- a/vim/init.vim
+++ b/vim/init.vim
@@ -282,8 +282,11 @@ set wildignore+=*.bmp,*.png,*.jpg,*.jpeg,*.gif
 set wildignore+=*.so,*.swp,*.zip,*.bz2
 " allow unsaved buffers to go into the background
 set hidden
-" real-time replacement
-set inccommand=nosplit
+" neovim specific config
+if has('nvim')
+  " real-time replacement
+  set inccommand=nosplit
+endif
 
 " don't clutter cwd with backup and swap files
 set backupdir^=~/.vim/.backup

--- a/vim/init.vim
+++ b/vim/init.vim
@@ -86,14 +86,9 @@ call plug#begin('~/.vim/plugged')
   " nerdtree
   Plug 'scrooloose/nerdtree'
 
-  " supertab (for autocompletion)
-  Plug 'ervandew/supertab'
-
   " autocompletion
   if has('nvim')
-    silent !pip3 install pynvim
-    Plug 'Shougo/deoplete.nvim', { 'do': ':UpdateRemotePlugins' }
-    " Plug 'fishbullet/deoplete-ruby'
+    Plug 'neoclide/coc.nvim', {'do': 'yarn install --frozen-lockfile'}
   else
     silent !pip3 install pynvim
     Plug 'Shougo/deoplete.nvim'
@@ -114,6 +109,10 @@ call plug#begin('~/.vim/plugged')
   Plug 'peitalin/vim-jsx-typescript'
   Plug 'ternjs/tern_for_vim', { 'do': 'npm install' }
 
+  " typscript
+  Plug 'ianks/vim-tsx'
+  Plug 'leafgarland/typescript-vim'
+
   " tmux
   Plug 'christoomey/vim-tmux-navigator'
 
@@ -128,14 +127,39 @@ call plug#begin('~/.vim/plugged')
 
 call plug#end()
 
+" coc extensions
+let g:coc_global_extensions = ['coc-tslint-plugin', 'coc-eslint', 'coc-tsserver', 'coc-emmet', 'coc-css', 'coc-html', 'coc-json', 'coc-yank', 'coc-prettier']
+
+" use <tab> for trigger completion and navigate to the next complete item
+function! s:check_back_space() abort
+  let col = col('.') - 1
+  return !col || getline('.')[col - 1]  =~ '\s'
+endfunction
+
+inoremap <silent><expr> <Tab>
+      \ pumvisible() ? "\<C-n>" :
+      \ <SID>check_back_space() ? "\<Tab>" :
+      \ coc#refresh()
+
+inoremap <expr> <cr> pumvisible() ? "\<C-y>" : "\<C-g>u\<CR>"
+
+inoremap <expr> <Tab> pumvisible() ? "\<C-n>" : "\<Tab>"
+inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
+
+augroup typescript_register
+  autocmd BufNewFile,BufRead *.ts setlocal filetype=typescript
+  autocmd BufNewFile,BufRead *.tsx setlocal filetype=typescript.tsx
+augroup END
+
+augroup json_comments
+  autocmd FileType json syntax match Comment +\/\/.\+$+
+augroup END
+
 " allow autocompletion on all filetypes except txt
 let g:deoplete#enable_at_startup=1
 augroup deoplete_configs
   autocmd FileType tex call deoplete#custom#buffer_option('auto_complete', v:false)
 augroup END
-" Enter maps to completion
-let g:SuperTabCrMapping = 1
-let g:SuperTabDefaultCompletionType = "<c-n>"
 
 " allow closetags
 let g:closetag_filenames = "*.html,*.xhtml,*.phtml,*.xml,*.php,*.jsx"

--- a/vim/init.vim
+++ b/vim/init.vim
@@ -133,10 +133,12 @@ call plug#begin('~/.vim/plugged')
 
 call plug#end()
 
-" coc extensions
+" coc extensions (:CocConfig)
 augroup coc_plugins
   autocmd!
-  autocmd Filetype python let g:coc_global_extensions = ['coc-json', 'coc-yank', 'coc-python']
+  " Python projects (https://github.com/fannheyward/coc-pyright)
+  autocmd Filetype python let g:coc_global_extensions = ['coc-json', 'coc-yank', 'coc-pyright']
+  " TS/JS projects (https://github.com/neoclide/coc-tsserver)
   autocmd Filetype javascriptreact,javascript let g:coc_global_extensions = [
     \'coc-tslint-plugin',
     \'coc-eslint',

--- a/vim/init.vim
+++ b/vim/init.vim
@@ -64,7 +64,7 @@ call plug#begin('~/.vim/plugged')
   Plug 'townk/vim-autoclose'
 
   " commenting
-  Plug 'tomtom/tcomment_vim'
+  Plug 'tpope/vim-commentary'
 
   " isolated view
   Plug 'chrisbra/NrrwRgn'

--- a/vim/init.vim
+++ b/vim/init.vim
@@ -101,7 +101,7 @@ call plug#begin('~/.vim/plugged')
   " nerdtree
   Plug 'scrooloose/nerdtree'
 
-  " autocompletion
+  " autocompletion & language server
   if has('nvim')
     Plug 'neoclide/coc.nvim', {'do': 'yarn install --frozen-lockfile'}
   else

--- a/vim/init.vim
+++ b/vim/init.vim
@@ -139,7 +139,7 @@ augroup coc_plugins
   " Python projects (https://github.com/fannheyward/coc-pyright)
   autocmd Filetype python let g:coc_global_extensions = ['coc-json', 'coc-yank', 'coc-pyright']
   " TS/JS projects (https://github.com/neoclide/coc-tsserver)
-  autocmd Filetype javascriptreact,javascript let g:coc_global_extensions = [
+  autocmd Filetype javascriptreact,typescriptreact,javascript,typescript let g:coc_global_extensions = [
     \'coc-tslint-plugin',
     \'coc-eslint',
     \'coc-tsserver',
@@ -155,8 +155,10 @@ augroup END
 augroup coc_workspace_roots
   autocmd!
   autocmd Filetype python let b:coc_root_patterns = ['.git', 'requirements.txt']
-  autocmd Filetype javascriptreact let b:coc_root_patterns = ['.git', 'package.json']
-  autocmd Filetype javascript let b:coc_root_patterns = ['.git', 'package.json']
+  autocmd Filetype javascriptreact,typescriptreact,javascript,typescript let b:coc_root_patterns = [
+    \'.git',
+    \'package.json'
+    \]
 augroup END
 
 " use <tab> for trigger completion and navigate to the next complete item

--- a/vim/init.vim
+++ b/vim/init.vim
@@ -111,22 +111,16 @@ call plug#begin('~/.vim/plugged')
     Plug 'roxma/vim-hug-neovim-rpc'
   endif
 
-  " python
-  Plug 'davidhalter/jedi-vim'
+  " typscript
+  Plug 'leafgarland/typescript-vim'
+  Plug 'peitalin/vim-jsx-typescript'
 
   " javascript
-  Plug 'MaxMEllon/vim-jsx-pretty'
-  Plug 'digitaltoad/vim-pug'
-  Plug 'jparise/vim-graphql'
-  Plug 'leafgarland/typescript-vim'
   Plug 'moll/vim-node'
   Plug 'pangloss/vim-javascript'
-  Plug 'peitalin/vim-jsx-typescript'
-  Plug 'ternjs/tern_for_vim', { 'do': 'npm install' }
-
-  " typscript
-  Plug 'ianks/vim-tsx'
-  Plug 'leafgarland/typescript-vim'
+  Plug 'jparise/vim-graphql'
+  Plug 'yuezk/vim-js'
+  Plug 'MaxMEllon/vim-jsx-pretty'
 
   " tmux
   Plug 'christoomey/vim-tmux-navigator'
@@ -140,7 +134,6 @@ call plug#begin('~/.vim/plugged')
 call plug#end()
 
 " coc extensions
-
 augroup coc_plugins
   autocmd!
   autocmd Filetype python let g:coc_global_extensions = ['coc-json', 'coc-yank', 'coc-python']
@@ -181,7 +174,7 @@ inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
 augroup typescript_register
   autocmd!
   autocmd BufNewFile,BufRead *.ts setlocal filetype=typescript
-  autocmd BufNewFile,BufRead *.tsx setlocal filetype=typescript.tsx
+  autocmd BufNewFile,BufRead *.tsx,*.jsx setlocal filetype=typescriptreact
 augroup END
 
 augroup json_comments
@@ -258,12 +251,6 @@ if executable('ag')
   " configure ack.vim to use ag
   let g:ackprg = 'ag --vimgrep --smart-case'
 endif
-
-" tern
-augroup tern_js_config
-  autocmd!
-  autocmd CompleteDone * pclose
-augroup END
 
 " testing strategy
 let test#strategy = 'vimux'

--- a/vim/init.vim
+++ b/vim/init.vim
@@ -217,15 +217,6 @@ augroup nerdtree_configs
   autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists("s:std_in") | exe 'NERDTree' argv()[0] | wincmd p | ene | endif
 augroup END
 
-" rainbow parentheses
-" augroup parentheses_configs
-"   autocmd!
-"   autocmd VimEnter * RainbowParenthesesToggle
-"   autocmd Syntax * RainbowParenthesesLoadRound
-"   autocmd Syntax * RainbowParenthesesLoadSquare
-"   autocmd Syntax * RainbowParenthesesLoadBraces
-" augroup END
-
 " byobu style
 let g:airline_theme="base16"
 let g:airline#extensions#tabline#formatter='jsformatter'
@@ -457,12 +448,11 @@ if has("gui_macvim")
   set fuoptions=maxvert,maxhorz
 endif
 
-" for posterity
+" empower quick hops to this file for posterity
 nnoremap <leader>vimrc :tabedit $MYVIMRC
 
 " Use K to show documentation in preview window
 nnoremap <silent> K :call <SID>show_documentation()<CR>
-
 function! s:show_documentation()
   if (index(['vim','help'], &filetype) >= 0)
     execute 'h '.expand('<cword>')
@@ -470,3 +460,30 @@ function! s:show_documentation()
     call CocAction('doHover')
   endif
 endfunction
+
+" rainbow parentheses
+let g:rbpt_colorpairs = [
+    \ ['brown',       'RoyalBlue3'],
+    \ ['Darkblue',    'SeaGreen3'],
+    \ ['darkgray',    'DarkOrchid3'],
+    \ ['darkgreen',   'firebrick3'],
+    \ ['darkcyan',    'RoyalBlue3'],
+    \ ['darkred',     'SeaGreen3'],
+    \ ['darkmagenta', 'DarkOrchid3'],
+    \ ['brown',       'firebrick3'],
+    \ ['gray',        'RoyalBlue3'],
+    \ ['black',       'SeaGreen3'],
+    \ ['darkmagenta', 'DarkOrchid3'],
+    \ ['Darkblue',    'firebrick3'],
+    \ ['darkgreen',   'RoyalBlue3'],
+    \ ['darkcyan',    'SeaGreen3'],
+    \ ['darkred',     'DarkOrchid3'],
+    \ ['red',         'firebrick3'],
+    \ ]
+let g:rbpt_max = 16
+augroup parentheses_configs
+  autocmd VimEnter * RainbowParenthesesToggle
+  autocmd Syntax * RainbowParenthesesLoadRound
+  autocmd Syntax * RainbowParenthesesLoadSquare
+  autocmd Syntax * RainbowParenthesesLoadBraces
+augroup END

--- a/vim/init.vim
+++ b/vim/init.vim
@@ -210,13 +210,13 @@ augroup nerdtree_configs
 augroup END
 
 " rainbow parentheses
-augroup parentheses_configs
-  autocmd!
-  autocmd VimEnter * RainbowParenthesesToggle
-  autocmd Syntax * RainbowParenthesesLoadRound
-  autocmd Syntax * RainbowParenthesesLoadSquare
-  autocmd Syntax * RainbowParenthesesLoadBraces
-augroup END
+" augroup parentheses_configs
+"   autocmd!
+"   autocmd VimEnter * RainbowParenthesesToggle
+"   autocmd Syntax * RainbowParenthesesLoadRound
+"   autocmd Syntax * RainbowParenthesesLoadSquare
+"   autocmd Syntax * RainbowParenthesesLoadBraces
+" augroup END
 
 " byobu style
 let g:airline_theme="base16"
@@ -454,3 +454,20 @@ endif
 
 " for posterity
 nnoremap <leader>vimrc :tabedit $MYVIMRC
+
+" load node modules
+set path=.,src
+set suffixesadd=.js,.jsx,.ts,.tsx,.json
+
+function! LoadMainNodeModule(fname)
+  let nodeModules = "./node_modules/"
+  let packageJsonPath = nodeModules . a:fname . "package.json"
+
+  if filereadable(packageJsonPath)
+      return nodeModules . a:fname . "/" . json_decode(join(readfile(packageJsonPath))).main
+  else
+      return nodeModules . a:fname
+  endif
+endfunction
+
+set includeexpr=LoadMainNodeModule(v:fname)

--- a/vim/init.vim
+++ b/vim/init.vim
@@ -1,4 +1,4 @@
-" a nice lil' (neo)vim config
+" Nice lil' ("neo-"/"gui-" compatible) vim config
 " (requires python3 install)
 
 " safety first

--- a/vim/init.vim
+++ b/vim/init.vim
@@ -457,19 +457,13 @@ endif
 " for posterity
 nnoremap <leader>vimrc :tabedit $MYVIMRC
 
-" load node modules
-set path=.,src
-set suffixesadd=.js,.jsx,.ts,.tsx,.json
+" Use K to show documentation in preview window
+nnoremap <silent> K :call <SID>show_documentation()<CR>
 
-function! LoadMainNodeModule(fname)
-  let nodeModules = "./node_modules/"
-  let packageJsonPath = nodeModules . a:fname . "package.json"
-
-  if filereadable(packageJsonPath)
-      return nodeModules . a:fname . "/" . json_decode(join(readfile(packageJsonPath))).main
+function! s:show_documentation()
+  if (index(['vim','help'], &filetype) >= 0)
+    execute 'h '.expand('<cword>')
   else
-      return nodeModules . a:fname
+    call CocAction('doHover')
   endif
 endfunction
-
-set includeexpr=LoadMainNodeModule(v:fname)

--- a/zsh/zshrc.sh
+++ b/zsh/zshrc.sh
@@ -96,17 +96,19 @@ setopt AUTO_PUSHD
 setopt AUTO_CD
 
 # fasd
-eval "$(fasd --init auto)"
-alias a='fasd -a'        # any
-alias s='fasd -si'       # show / search / select
-alias d='fasd -d'        # directory
-alias f='fasd -f'        # file
-alias sd='fasd -sid'     # interactive directory selection
-alias sf='fasd -sif'     # interactive file selection
-alias z='fasd_cd -d'     # cd, same functionality as j in autojump
-alias zz='fasd_cd -d -i' # cd with interactive selection
-alias v='f -e vim'       # open in (neo-)vim
-export _FASD_MAX=1000
+if [[ "$(command -v fasd)" ]]; then
+  eval "$(fasd --init auto)"
+  alias a='fasd -a'        # any
+  alias s='fasd -si'       # show / search / select
+  alias d='fasd -d'        # directory
+  alias f='fasd -f'        # file
+  alias sd='fasd -sid'     # interactive directory selection
+  alias sf='fasd -sif'     # interactive file selection
+  alias z='fasd_cd -d'     # cd, same functionality as j in autojump
+  alias zz='fasd_cd -d -i' # cd with interactive selection
+  alias v='f -e vim'       # open in (neo-)vim
+  export _FASD_MAX=1000
+fi
 
 # safety first
 set -o noclobber         # Do not overwrite files via '>'

--- a/zsh/zshrc.sh
+++ b/zsh/zshrc.sh
@@ -96,19 +96,17 @@ setopt AUTO_PUSHD
 setopt AUTO_CD
 
 # fasd
-if [[ "$(command -v fasd)" ]]; then
-  eval "$(fasd --init auto)"
-  alias a='fasd -a'        # any
-  alias s='fasd -si'       # show / search / select
-  alias d='fasd -d'        # directory
-  alias f='fasd -f'        # file
-  alias sd='fasd -sid'     # interactive directory selection
-  alias sf='fasd -sif'     # interactive file selection
-  alias z='fasd_cd -d'     # cd, same functionality as j in autojump
-  alias zz='fasd_cd -d -i' # cd with interactive selection
-  alias v='f -e vim'       # open in (neo-)vim
-  export _FASD_MAX=1000
-fi
+eval "$(fasd --init auto)"
+alias a='fasd -a'        # any
+alias s='fasd -si'       # show / search / select
+alias d='fasd -d'        # directory
+alias f='fasd -f'        # file
+alias sd='fasd -sid'     # interactive directory selection
+alias sf='fasd -sif'     # interactive file selection
+alias z='fasd_cd -d'     # cd, same functionality as j in autojump
+alias zz='fasd_cd -d -i' # cd with interactive selection
+alias v='f -e vim'       # open in (neo-)vim
+export _FASD_MAX=1000
 
 # safety first
 set -o noclobber         # Do not overwrite files via '>'


### PR DESCRIPTION
## Changes in this PR
Move from `tern` & `deoplete` to `coc.nvim` sponsored plugins for async language server operations.

General project settings can be specified via `:CocConfig` and local projects can configure via `:CocLocalConfig`

**Various `vim` config improvements**
* Correct parenthesis highlighting
* Improve `gf` path resolution in JS apps for node modules
* Fix warnings in standard vim from `inccomand` setting