### PR TITLE
fix: correct macosx architecture

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,3 +1,5 @@
+if-shell '[ "$(uname -m)" = "arm64" ]' 'set-option -g default-command arch -arch arm64 /bin/zsh'
+
 source-file ~/.dotfiles/tmux/tmux-keybindings.conf
 
 # remove tmux escape delay

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,4 +1,4 @@
-if-shell '[ "$(uname -m)" = "arm64" ]' 'set-option -g default-command arch -arch arm64 /bin/zsh'
+if-shell '[ "$(uname -m)" = "arm64" ]' 'set-option -g default-command "arch -arch arm64 $SHELL"'
 
 source-file ~/.dotfiles/tmux/tmux-keybindings.conf
 


### PR DESCRIPTION
For those of us with universal binaries, ensure that the terminal multiplexer boots into native.

May require a fresh homebrew install for existing users on silicon.